### PR TITLE
small-css-fixes

### DIFF
--- a/css/customer/case-css.css
+++ b/css/customer/case-css.css
@@ -84,6 +84,13 @@
     cursor: pointer;
     transition: background 0.2s ease;
 }
+
+@media(max-width: 980px){
+    #back-button {
+        font-size: 3rem;
+    }
+}
+
 #back-button:hover {
     background: rgba(44, 142, 214, 0.8);
 }

--- a/css/customer/cases-css.css
+++ b/css/customer/cases-css.css
@@ -34,10 +34,22 @@ body {
     letter-spacing: 1px;
 }
 
+@media(max-width: 980px){
+    .overview-title h1 {
+        font-size: 70px;
+    }
+}
+
 .overview-title p {
     font-size: 1rem;
     color: #555;                 /* en mere dæmpet undertone */
     margin: 0;
+}
+
+@media(max-width: 980px){
+    .overview-title p {
+        font-size: 35px;
+    }
 }
 
 /* Horisontal linje mellem overview-title og cases */

--- a/css/customer/cookie-consent.css
+++ b/css/customer/cookie-consent.css
@@ -51,6 +51,12 @@
     background-color: #333333;
 }
 
+@media(max-width: 980px){
+    #accept-essential-cookies{
+        font-size: 30px;
+    }
+}
+
 #accept-essential-cookies:hover{
     background-color: #6c6c6c;
 }
@@ -69,6 +75,12 @@
 
 #accept-cookies {
     background-color: #006400;
+}
+
+@media(max-width: 980px){
+    #accept-cookies {
+        font-size: 30px;
+    }
 }
 
 #accept-cookies:hover {

--- a/css/customer/headerANDfooter/header.css
+++ b/css/customer/headerANDfooter/header.css
@@ -29,6 +29,18 @@ header{
     border: 0;
 }
 
+li.mobile-liner-li{
+    width: 0;
+    padding: 0 !important;
+    height: 0;
+    margin: 0;
+    border: 0;
+}
+
+li#mobile-liner-li-id {
+    padding: 0.7rem !important;
+}
+
 .nav-list li a::after {
     content: "";
     position: absolute;
@@ -74,6 +86,7 @@ header{
     height: 80px;
     width: 110px;
     background-size: cover;
+    margin-right: 2rem;
 }
 
 @media(max-width: 980px){

--- a/html/customer/headerANDfooter/header.html
+++ b/html/customer/headerANDfooter/header.html
@@ -24,19 +24,19 @@
     <nav>
         <div id="medialogo"><a id="logo2" href="#" aria-label="Redirect to frontpage/index"></a></div>
         <ul class="nav-list">
-            <li><hr class="mobile-liner"></li>
+            <li class="mobile-liner-li"><hr class="mobile-liner"></li>
             <li><a id="ydelser" href="#">Ydelser</a></li>
-            <li><hr class="mobile-liner"></li>
+            <li class="mobile-liner-li"><hr class="mobile-liner"></li>
             <li><a id="cases" href="#">Cases</a></li>
-            <li><hr class="mobile-liner"></li>
+            <li class="mobile-liner-li"><hr class="mobile-liner"></li>
             <li class="logo">
                 <a id="logo" href="#" aria-label="Redirect to frontpage/index">
                 </a>
             </li>
             <li><a id="omos" href="#">Om os</a></li>
-            <li><hr class="mobile-liner"></li>
+            <li class="mobile-liner-li"><hr class="mobile-liner"></li>
             <li><a id="kontakt" href="#">Kontakt</a></li>
-            <li><hr class="mobile-liner"></li>
+            <li class="mobile-liner-li" id="mobile-liner-li-id"><hr class="mobile-liner"></li>
         </ul>
 
 

--- a/js/headerANDfooter/headerANDfooter.js
+++ b/js/headerANDfooter/headerANDfooter.js
@@ -87,7 +87,7 @@ function loadNavLogic() {
     if (serviceLink) {
         serviceLink.addEventListener('click', function(event) {
             event.preventDefault(); // gør det muligt at selv programmere sidens adfærd
-            window.location.href = "#services"; //hardcoded fil navn til navigation
+            window.location.href = "index.html#services"; //hardcoded fil navn til navigation
         });
     }
 
@@ -133,7 +133,7 @@ function loadNavLogic() {
     if (contactLink) {
         contactLink.addEventListener('click', function(event) {
             event.preventDefault();
-            window.location.href = "#contact";
+            window.location.href = "index.html#contact";
         });
     }
     // Sticky Header logikken skal hænger sammen med navigations logikken


### PR DESCRIPTION
have centeret the front icon dm-datamaster percisely in the center, plus made space between that and "om os". Also now the navigition between cases/about-us can to ydelser/kontakt now works. it will now go to index and scroll to the appropriated section id. Another ting is on mobile view the buttons accept/necessary-only have been made bigger, as have the the back button on case.html. The headline on cases has also been made bigger and the text under. 